### PR TITLE
fix: add mutex locking for imu_buffer_ concurrent access

### DIFF
--- a/src/core/lio/laser_mapping.cc
+++ b/src/core/lio/laser_mapping.cc
@@ -311,10 +311,14 @@ bool LaserMapping::Run() {
     kf_imu_ = kf_;
     if (!measures_.imu_.empty()) {
         double t = measures_.imu_.back()->timestamp;
-        for (auto &imu : imu_buffer_) {
-            double dt = imu->timestamp - t;
-            kf_imu_.Predict(dt, p_imu_->Q_, imu->angular_velocity, imu->linear_acceleration);
-            t = imu->timestamp;
+        {
+            UL lock(mtx_buffer_);
+            for (auto &imu : imu_buffer_) {
+                if (!imu) { continue; }
+                double dt = imu->timestamp - t;
+                kf_imu_.Predict(dt, p_imu_->Q_, imu->angular_velocity, imu->linear_acceleration);
+                t = imu->timestamp;
+            }
         }
     }
 
@@ -477,6 +481,7 @@ void LaserMapping::ProcessPointCloud2(CloudPtr cloud) {
 }
 
 bool LaserMapping::SyncPackages() {
+    UL lock(mtx_buffer_);
     if (lidar_buffer_.empty() || imu_buffer_.empty()) {
         LOG(INFO) << "lidar or imu is empty";
         return false;


### PR DESCRIPTION
## Problem

`imu_buffer_` (`std::deque<IMUPtr>`) is accessed from multiple threads:

| Location | Method | Holds `mtx_buffer_`? |
|----------|--------|----------------------|
| L143-166 | `ProcessIMU()` | ✅ Yes |
| L314-319 | `Run()` iteration | ❌ **No** |
| L480-532 | `SyncPackages()` | ❌ **No** |

When `ProcessIMU()` does `push_back` (which may trigger deque memory reallocation) while `SyncPackages()` or `Run()` is iterating, the iterator is invalidated → **Segmentation fault**.

## Fix

Add `UL lock(mtx_buffer_)` in two locations:

1. **`Run()` L314**: Wrap the `imu_buffer_` iteration with lock + null pointer guard
2. **`SyncPackages()` L479**: Add lock at function entry to protect all buffer accesses

**File:** `src/core/lio/laser_mapping.cc` (+9/-4 lines)

## Why no deadlock

- `SyncPackages()` and `Run()` are called sequentially (not nested)
- Both locks are non-reentrant but never held simultaneously
- `ProcessIMU()` is a separate ROS callback thread, only mutually exclusive with these two

Fixes #120